### PR TITLE
fix error of `MUI: You need to provide a value prop when using the determinate or buffer variant of LinearProgress .`

### DIFF
--- a/src/layout/MainLayout/Sidebar/MenuCard/index.js
+++ b/src/layout/MainLayout/Sidebar/MenuCard/index.js
@@ -69,7 +69,7 @@ function LinearProgressWithLabel({ value, ...others }) {
                 </Grid>
             </Grid>
             <Grid item>
-                <BorderLinearProgress variant="determinate" {...others} />
+                <BorderLinearProgress variant="determinate" value={value} {...others} />
             </Grid>
         </Grid>
     );


### PR DESCRIPTION
fix error of `index.js:1 MUI: You need to provide a value prop when using the determinate or buffer variant of LinearProgress .`

This error is always reproducing when app is loaded on development environment only.

![image](https://user-images.githubusercontent.com/6068828/146748203-b88b5593-9b5d-4d27-a0f8-c603693567d2.png)

