### PR TITLE
fix content resize when drawer opens

### DIFF
--- a/src/layout/MainLayout/index.js
+++ b/src/layout/MainLayout/index.js
@@ -21,45 +21,35 @@ import { IconChevronRight } from '@tabler/icons';
 // styles
 const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(({ theme, open }) => ({
     ...theme.typography.mainContent,
-    ...(!open && {
-        borderBottomLeftRadius: 0,
-        borderBottomRightRadius: 0,
-        transition: theme.transitions.create('margin', {
-            easing: theme.transitions.easing.sharp,
-            duration: theme.transitions.duration.leavingScreen
-        }),
-        [theme.breakpoints.up('md')]: {
-            marginLeft: -(drawerWidth - 20),
-            width: `calc(100% - ${drawerWidth}px)`
-        },
-        [theme.breakpoints.down('md')]: {
-            marginLeft: '20px',
-            width: `calc(100% - ${drawerWidth}px)`,
-            padding: '16px'
-        },
-        [theme.breakpoints.down('sm')]: {
-            marginLeft: '10px',
-            width: `calc(100% - ${drawerWidth}px)`,
-            padding: '16px',
-            marginRight: '10px'
-        }
-    }),
-    ...(open && {
-        transition: theme.transitions.create('margin', {
-            easing: theme.transitions.easing.easeOut,
-            duration: theme.transitions.duration.enteringScreen
-        }),
-        marginLeft: 0,
-        borderBottomLeftRadius: 0,
-        borderBottomRightRadius: 0,
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    transition: theme.transitions.create(
+        'margin',
+        open
+            ? {
+                  easing: theme.transitions.easing.easeOut,
+                  duration: theme.transitions.duration.enteringScreen
+              }
+            : {
+                  easing: theme.transitions.easing.sharp,
+                  duration: theme.transitions.duration.leavingScreen
+              }
+    ),
+    [theme.breakpoints.up('md')]: {
+        marginLeft: open ? 0 : -(drawerWidth - 20),
+        width: `calc(100% - ${drawerWidth}px)`
+    },
+    [theme.breakpoints.down('md')]: {
+        marginLeft: open ? 0 : '20px',
         width: `calc(100% - ${drawerWidth}px)`,
-        [theme.breakpoints.down('md')]: {
-            marginLeft: '20px'
-        },
-        [theme.breakpoints.down('sm')]: {
-            marginLeft: '10px'
-        }
-    })
+        padding: '16px'
+    },
+    [theme.breakpoints.down('sm')]: {
+        marginLeft: open ? 0 : '10px',
+        width: `calc(100% - ${drawerWidth}px)`,
+        padding: '16px',
+        marginRight: '10px'
+    }
 }));
 
 // ==============================|| MAIN LAYOUT ||============================== //


### PR DESCRIPTION
to reproduce, just go to https://berrydashboard.io/free/dashboard/default toggle device emulation and select a small phone, as  you open and close the sidebar you can see the `<Main>` component padding changing