### PR TITLE
Remove repetitive use of darkTitle prop

### DIFF
--- a/src/ui-component/cards/MainCard.js
+++ b/src/ui-component/cards/MainCard.js
@@ -46,10 +46,9 @@ const MainCard = forwardRef(
                 }}
             >
                 {/* card header and action */}
-                {!darkTitle && title && <CardHeader sx={headerSX} title={title} action={secondary} />}
-                {darkTitle && title && (
-                    <CardHeader sx={headerSX} title={<Typography variant="h3">{title}</Typography>} action={secondary} />
-                )}
+                {title && 
+                    ( <CardHeader sx={headerSX} title={ darkTitle? <Typography variant="h3">{title}</Typography> : title } action={secondary} /> )
+                } 
 
                 {/* content & header divider */}
                 {title && <Divider />}


### PR DESCRIPTION
Remove the repetitive use darkTitle prop and instead use the title prop to pass in a Typography component with the variant of "h3" to achieve the same effect. This simplifies the code and makes it more readable. 

Updated code uses a ternary operator to check the value of darkTitle and conditionally render the title prop with or without the Typography component.

### Commit Checklist

- [x] Remove UNUSED comment code
- [x] Remove any logging like console.log
- [x] Remove all warnings and errors while build
- [x] Make sure build for production is working. Try running command for prod build in local.
- [] Fix prettier: `npx prettier --write .`
- [] Fix eslint: `npx eslint src\ --fix ` command
- [] Push package.lock only if you used npm, push yarn.lock only if you used yarn. NPM will udpate both lock file so make sure you dont push yarn.lock updated by NPM

### General
- [x] Follow import structure. module/third-party/files/component/style/types/asset
- [x] Follow project directory structure
- [ ] To create any new page follow our sample page or any other page
- [ ] Try to use theme for design like palette, typography, variant, components, etc. (don't use custom color code anyhow)
- [ ] Before adding custom style/sx follow our pre-built components/elements (use the minimum number of sx styles)
- [ ] For the main section use the Grid component and for the sub-section - use the Stack component
- [x] Check all files changed by you in vs code and only commit needed once
- [ ] When you rename file or directory, use the command code (don't rename pushed files manually)
