### PR TITLE
chore: avoid pass theme prop to the dom

### DIFF
--- a/create-react-app/src/layout/MainLayout/index.js
+++ b/create-react-app/src/layout/MainLayout/index.js
@@ -18,7 +18,7 @@ import { SET_MENU } from 'store/actions';
 import { IconChevronRight } from '@tabler/icons';
 
 // styles
-const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })(({ theme, open }) => ({
+const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' && prop !== 'theme' })(({ theme, open }) => ({
   ...theme.typography.mainContent,
   borderBottomLeftRadius: 0,
   borderBottomRightRadius: 0,


### PR DESCRIPTION

### Description
When the `MainLayout` render, the `theme` prop is passed to the DOM as [object Object] as you can see in the image below.
It was changed the logic of the `Main` component -> `shouldForwardProp` to avoid pass the prop. 

### Screenshot
<img width="522" alt="Screenshot 2023-09-16 at 13 19 58" src="https://github.com/codedthemes/berry-free-react-admin-template/assets/18473317/f2202819-a73d-4eca-9232-53d5e1a42597">


<br />
<br />


- [x] Remove UNUSED comment code
- [x] Remove any logging like console.log
- [x] Remove all warnings and errors while build
- [x] Check vulnerabilities
- [x] Make sure build for production is working. Try running command for prod build in local.
- [x] Fix prettier: `npx prettier --write .`
- [x] Fix eslint: `npx eslint src\ --fix ` command
- [x] Push package.lock only if you used npm, push yarn.lock only if you used yarn. NPM will udpate both lock file so make sure you dont push yarn.lock updated by NPM
- [x] WCAG

### General
- [ ] Follow import structure. module/third-party/files/component/style/types/asset
- [ ] Try to use theme for design like palette, typography, variant, components, etc. (don't use custom color code anyhow)
- [ ] Before adding custom style follow our pre-built components/elements

