### PR TITLE
fix: changed "Twitter" to "𝕏 (Twitter)" In README.md Follow us Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ To report a bug, please submit an [issue](https://github.com/codedthemes/berry-f
 -   [CodedThemes](https://codedthemes.com)
 -   [Dribbble](https://dribbble.com/codedthemes)
 -   [Facebook](https://www.facebook.com/codedthemes)
--   [Twitter](https://twitter.com/codedthemes)
+-   [𝕏 (Twitter)](https://twitter.com/codedthemes)


### PR DESCRIPTION
changed "Twitter" to "𝕏 (Twitter)"



This fixes https://github.com/codedthemes/berry-free-react-admin-template/issues/77

