### PR TITLE
docs: add Deploy on Hostinger button

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,7 @@ To report a bug, please submit an [issue](https://github.com/codedthemes/berry-f
 - [LinkedIn](https://www.linkedin.com/company/codedthemes/) 💼
 - [Instagram](https://www.instagram.com/codedthemes/) 📷
 - [Facebook](https://www.facebook.com/codedthemes) 🟦
+
+## Deployment
+
+[![Deploy on Hostinger](https://assets.hostinger.com/vps/deploy.svg)](https://www.hostinger.com/web-apps-hosting)


### PR DESCRIPTION
This PR adds an optional **Deploy on Hostinger** badge to the README (docs-only change).

- Only README is changed
- No code, runtime, or build behavior changes
- The destination URL can be maintainer-controlled (standard Hostinger page or your own partner/affiliate link)

If this is not aligned with project policy, I can close the PR.